### PR TITLE
feat: NGワードゲームにワード重複防止ロジックを追加

### DIFF
--- a/backend/functions/src/handlers/games/0001/declare.js
+++ b/backend/functions/src/handlers/games/0001/declare.js
@@ -1,5 +1,6 @@
 const {logger} = require("firebase-functions");
 const {db} = require("../../../config/firebase");
+const {assignNgWords} = require("./init");
 const {
   throwValidationError,
   throwGameStatusError,
@@ -64,32 +65,14 @@ async function declare0001Handler(request) {
 
         updateData.gameStatus = "waiting";
 
-        const ngWordsDoc = await transaction.get(
-            db.collection("games").doc("0001")
-                .collection("assets")
-                .doc("ngWords"),
-        );
+        const playerUids = Object.keys(playersWithUpdatedPoints);
+        const newGameData = await assignNgWords(playerUids, {
+          usedWords: currentGameData.usedWords || [],
+          players: playersWithUpdatedPoints,
+        });
 
-        if (!ngWordsDoc.exists) {
-          throwStructuredError("Internal", "NGワードリストが見つかりません");
-        }
-
-        const ngWordsList = ngWordsDoc.data().words;
-        const shuffledWords = shuffleArray(ngWordsList);
-
-        const finalPlayers = Object.fromEntries(
-            Object.keys(playersWithUpdatedPoints).map((uid, index) => [
-              uid,
-              {
-                isReady: false,
-                ngWord: [shuffledWords[index % shuffledWords.length]],
-                isAlive: true,
-                point: playersWithUpdatedPoints[uid].point || 0,
-              },
-            ]),
-        );
-
-        updateData.players = finalPlayers;
+        updateData.players = newGameData.players;
+        updateData.usedWords = newGameData.usedWords;
       }
 
       transaction.update(currentGameRef, updateData);
@@ -117,20 +100,6 @@ async function declare0001Handler(request) {
     });
     throwStructuredError("Internal", "サーバーエラーが発生しました。");
   }
-}
-
-/**
- * NGワードをシャッフルする
- * @param {Array<string>} array - 文字列が格納された配列
- * @return {Array<string>} ランダムに並び替えられた配列
- */
-function shuffleArray(array) {
-  const newArray = [...array];
-  for (let i = newArray.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
-  }
-  return newArray;
 }
 
 module.exports = {

--- a/backend/functions/src/handlers/games/0001/init.js
+++ b/backend/functions/src/handlers/games/0001/init.js
@@ -6,6 +6,23 @@ const {db} = require("../../../config/firebase");
  * @return {Promise<Object>} currentGameデータ
  */
 async function createCurrentGame(players) {
+  const playerUids = Object.keys(players);
+  const gameData = await assignNgWords(playerUids);
+
+  return {
+    gameStatus: "waiting",
+    players: gameData.players,
+    usedWords: gameData.usedWords,
+  };
+}
+
+/**
+ * プレイヤーにNGワードを割り当てる
+ * @param {Array<string>} playerUids - プレイヤーのuidの配列
+ * @param {Object} existingGameData - 既存のゲームデータ（継続時）
+ * @return {Promise<Object>} NGワード割り当て結果
+ */
+async function assignNgWords(playerUids, existingGameData = null) {
   const ngWordsDoc = await db.collection("games").doc("0001")
       .collection("assets")
       .doc("ngWords")
@@ -15,22 +32,39 @@ async function createCurrentGame(players) {
     throw new Error("NGワードリストが見つかりません");
   }
 
-  const ngWordsList = ngWordsDoc.data().words;
-  const shuffledWords = shuffleArray(ngWordsList);
-  const playerUids = Object.keys(players);
+  const allWords = ngWordsDoc.data().words;
+
+  if (allWords.length < playerUids.length) {
+    throw new Error("NGワードが不足しています");
+  }
+
+  let usedWords = existingGameData?.usedWords || [];
+  const unusedWords = allWords.filter((word) => !usedWords.includes(word));
+  let selectedWords;
+
+  if (unusedWords.length >= playerUids.length) {
+    const shuffled = shuffleArray(unusedWords);
+    selectedWords = shuffled.slice(0, playerUids.length);
+    usedWords = [...usedWords, ...selectedWords];
+  } else {
+    const shuffled = shuffleArray(allWords);
+    selectedWords = shuffled.slice(0, playerUids.length);
+    usedWords = [...selectedWords];
+  }
+
   const playersData = {};
   playerUids.forEach((uid, index) => {
     playersData[uid] = {
       isReady: false,
-      ngWord: [shuffledWords[index % shuffledWords.length]],
+      ngWord: [selectedWords[index]],
       isAlive: true,
-      point: 0,
+      point: existingGameData?.players?.[uid]?.point || 0,
     };
   });
 
   return {
-    gameStatus: "waiting",
     players: playersData,
+    usedWords: usedWords,
   };
 }
 
@@ -50,4 +84,5 @@ function shuffleArray(array) {
 
 module.exports = {
   createCurrentGame,
+  assignNgWords,
 };


### PR DESCRIPTION
偏見プロフィールゲームと同様のロジックを実装し、一度使われたNGワードは
他の全てのワードが使い終わるまで再利用されないようにしました。

- usedWordsフィールドを追加して使用済みワードを管理
- assignNgWords関数を新規作成し、未使用ワードを優先的に選択
- 未使用ワードが不足した場合は全ワードからリセット
- declare.js とinit.js の両方で共通関数を使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)