### PR TITLE
fix: ゲーム終了時にisBurstがfalseにリセットされる不具合を修正

### DIFF
--- a/backend/functions/src/handlers/games/0006/init.js
+++ b/backend/functions/src/handlers/games/0006/init.js
@@ -72,7 +72,7 @@ async function reinitializeGame(currentGameData) {
       score: 0,
       lastScore: currentPlayer.score || 0,
       cardCount: 0,
-      isBurst: false,
+      isBurst: currentPlayer.isBurst || false,
     };
   });
 

--- a/backend/functions/src/handlers/games/management/setReady.js
+++ b/backend/functions/src/handlers/games/management/setReady.js
@@ -69,7 +69,11 @@ async function setReadyHandler(request) {
         updateData.players = Object.fromEntries(
             Object.entries(updatedPlayers).map(([uid, player]) => [
               uid,
-              {...player, isReady: false},
+              {
+                ...player,
+                isReady: false,
+                ...(player.isBurst !== undefined && {isBurst: false}),
+              },
             ]),
         );
       }


### PR DESCRIPTION
reinitializeGameでisBurstを即座にfalseにリセットしていたため、
結果画面（waiting状態）でバースト状態が失われていた。
isBurstをlastScoreと同様に前ゲームから保持し、
次ゲーム開始時（setReady全員完了時）にリセットするよう修正。

https://claude.ai/code/session_011578znkoNQyP1WZL5n2ei8